### PR TITLE
Always attempt to pull due to `latest` tags

### DIFF
--- a/cicd/jenkins/build_yaml/appstore-master.yaml
+++ b/cicd/jenkins/build_yaml/appstore-master.yaml
@@ -41,7 +41,7 @@ docker:
   secondary_docker_dir:
     null
   build_args:
-    null
+    "--pull"
 
 test:
   cmd_path:

--- a/cicd/jenkins/build_yaml/appstore.yaml
+++ b/cicd/jenkins/build_yaml/appstore.yaml
@@ -41,7 +41,7 @@ docker:
   secondary_docker_dir:
     null
   build_args:
-    null
+    "--pull"
 
 test:
   cmd_path:

--- a/cicd/jenkins/build_yaml/helx-ui-master.yaml
+++ b/cicd/jenkins/build_yaml/helx-ui-master.yaml
@@ -40,7 +40,7 @@ docker:
   secondary_docker_dir:
     null
   build_parameters:
-    null
+    "--pull"
 
 test:
   cmd_path:

--- a/cicd/jenkins/build_yaml/helx-ui.yaml
+++ b/cicd/jenkins/build_yaml/helx-ui.yaml
@@ -40,7 +40,7 @@ docker:
   secondary_docker_dir:
     null
   build_parameters:
-    null
+    "--pull"
 
 test:
   cmd_path:


### PR DESCRIPTION
Because we are using `latest` for some image tag references make
sure to have docker always attempt a pull incase the hash has
changed and an update is available.

[ref](https://github.com/helxplatform/devops/blob/91c2bc437b1c38ac4bd711c79612a3ddf0aa34c5/cicd/jenkins/bashlib/yaml_build.sh#L174)