### PR TITLE
Bump to node 14

### DIFF
--- a/cicd/jenkins/jenkins-master/docker/Dockerfile
+++ b/cicd/jenkins/jenkins-master/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debia
     curl -L https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -o /usr/local/bin/yq && \
     chmod +x /usr/local/bin/yq
 
-RUN curl -fsSL https://deb.nodesource.com/setup_10.x | bash - && \
+RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y nodejs
 
 RUN mkdir ruby && \


### PR DESCRIPTION
- Bumping to node 14 for lts support and alignment of node version with helx-ui.

https://nodejs.org/en/about/releases/

ref: helxplatform/development#700 helxplatform/helx-ui#41