### PR TITLE
Revert appstore command

### DIFF
--- a/helx/Chart.yaml
+++ b/helx/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.1.6
   - name: appstore
     condition: appstore.enabled
-    version: 0.1.26
+    version: 0.1.27
   - name: backup-pvc-cronjob
     condition: backup-pvc-cronjob.enabled
     version: 0.1.0

--- a/helx/charts/appstore/Chart.yaml
+++ b/helx/charts/appstore/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.26
+version: 0.1.27
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helx/charts/appstore/README.md
+++ b/helx/charts/appstore/README.md
@@ -1,6 +1,6 @@
 # appstore
 
-![Version: 0.1.26](https://img.shields.io/badge/Version-0.1.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.18](https://img.shields.io/badge/AppVersion-1.0.18-informational?style=flat-square)
+![Version: 0.1.27](https://img.shields.io/badge/Version-0.1.27-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.18](https://img.shields.io/badge/AppVersion-1.0.18-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/helx/charts/appstore/templates/deployment.yaml
+++ b/helx/charts/appstore/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ['/bin/bash', '-c']
-        args: ["make appstore.start brand={{ .Values.djangoSettings }}"]
+        args: ["bin/appstore updatedb {{ .Values.djangoSettings }} && bin/appstore createsuperuser && bin/appstore manageauthorizedusers {{ .Values.djangoSettings }} && bin/appstore run {{ .Values.djangoSettings }}"]
         # For debugging when things go wrong.
         # args: ["while true; do date; sleep 5; done"]
         resources:


### PR DESCRIPTION
- Revert until available in master

Reverting this for compatability with the latest image from appstore `master`. If you are deploying off a branch of develop in `appstore` you can use the `devops` branch [here](https://github.com/helxplatform/devops/tree/feature/appstore-deployment-update) in your namespace to have the updated `entrypoint` command.