### PR TITLE
Make appstore entrypoint a value

### DIFF
--- a/helx/Chart.yaml
+++ b/helx/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.1.6
   - name: appstore
     condition: appstore.enabled
-    version: 0.1.27
+    version: 0.1.28
   - name: backup-pvc-cronjob
     condition: backup-pvc-cronjob.enabled
     version: 0.1.0

--- a/helx/charts/appstore/Chart.yaml
+++ b/helx/charts/appstore/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.27
+version: 0.1.28
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helx/charts/appstore/README.md
+++ b/helx/charts/appstore/README.md
@@ -1,6 +1,6 @@
 # appstore
 
-![Version: 0.1.27](https://img.shields.io/badge/Version-0.1.27-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.18](https://img.shields.io/badge/AppVersion-1.0.18-informational?style=flat-square)
+![Version: 0.1.28](https://img.shields.io/badge/Version-0.1.28-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.18](https://img.shields.io/badge/AppVersion-1.0.18-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -16,6 +16,7 @@ A Helm chart for Kubernetes
 | appStorage.storageClass | string | `nil` |  |
 | appStorage.storageSize | string | `"2Gi"` |  |
 | apps.DICOMGH_GOOGLE_CLIENT_ID | string | `""` |  |
+| appstoreEntrypointArgs | string | `"bin/appstore updatedb cat && bin/appstore createsuperuser && bin/appstore manageauthorizedusers cat && bin/appstore run cat"` |  |
 | createHomeDirs | bool | `true` | Create Home directories for users |
 | db.name | string | `"appstore"` |  |
 | django.ALLOW_DJANGO_LOGIN | string | `""` | show Django log in fields (true | false) |

--- a/helx/charts/appstore/templates/deployment.yaml
+++ b/helx/charts/appstore/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ['/bin/bash', '-c']
-        args: ["bin/appstore updatedb {{ .Values.djangoSettings }} && bin/appstore createsuperuser && bin/appstore manageauthorizedusers {{ .Values.djangoSettings }} && bin/appstore run {{ .Values.djangoSettings }}"]
+        args: ["{{ .Values.appstoreEntrypointArgs}}"]
         # For debugging when things go wrong.
         # args: ["while true; do date; sleep 5; done"]
         resources:

--- a/helx/charts/appstore/values.yaml
+++ b/helx/charts/appstore/values.yaml
@@ -63,6 +63,8 @@ ambassador:
 
 # -- set the theme for appstore (cat, braini, restartr, scidas)
 djangoSettings: cat
+# Allow for a custom entrypoint command via the values file, make sure the djangoSettings and brand in entry are the same.
+appstoreEntrypointArgs: "bin/appstore updatedb cat && bin/appstore createsuperuser && bin/appstore manageauthorizedusers cat && bin/appstore run cat"
 
 django:
   # -- user emails for oauth providers


### PR DESCRIPTION
- Allows configuration of the entrypoint to support old and new `bin/appstore` or `make` launcher

Let me know what you think of this. I don't love hard coding the brand in the values entrypoint, but the path around that involves a fair bit of string interpolation, `tpl` etc. and seems like a pain point for future maintainers/users. Since `cat` is set in the variable right before, and somebody has to knowingly over ride this I don't think it's an issue.

I tested this in my namespace with the image `1.1.42` for the standard `bin/appstore` value and with image `1.1.65` and these values in my value file for override:

```
  djangoSettings: heal 
  appstoreEntrypointArgs: "make appstore.start brand=heal"
```

Both work as expected supporting both of the command types.