### PR TITLE
Rollback due to ENOTSUP error

### DIFF
--- a/cicd/jenkins/jenkins-master/docker/Dockerfile
+++ b/cicd/jenkins/jenkins-master/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debia
     curl -L https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -o /usr/local/bin/yq && \
     chmod +x /usr/local/bin/yq
 
-RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash - && \
+RUN curl -fsSL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -y nodejs
 
 RUN mkdir ruby && \


### PR DESCRIPTION
- https://jenkins.renci.org/job/helx-ui/37/console
- https://<span></span>github.com/nodejs/<span></span>node/issues/36439

Upstream node fix due in next LTS release, but this is blocking builds. Rolling back to version 12 maintenance LTS https://nodejs.org/en/about/releases/