### PR TITLE
Session timeout and removing 'brand' from appstore entrypoint command

### DIFF
--- a/helx/Chart.yaml
+++ b/helx/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.8.2
+version: 0.8.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -26,7 +26,7 @@ dependencies:
     version: 0.1.6
   - name: appstore
     condition: appstore.enabled
-    version: 0.1.29
+    version: 0.1.30
   - name: backup-pvc-cronjob
     condition: backup-pvc-cronjob.enabled
     version: 0.1.0

--- a/helx/Chart.yaml
+++ b/helx/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.8.3
+version: 0.8.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.4.5
+appVersion: 1.4.6
 
 dependencies:
   - name: ambassador
@@ -26,7 +26,7 @@ dependencies:
     version: 0.1.6
   - name: appstore
     condition: appstore.enabled
-    version: 0.1.30
+    version: 0.1.31
   - name: backup-pvc-cronjob
     condition: backup-pvc-cronjob.enabled
     version: 0.1.0

--- a/helx/README.md
+++ b/helx/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying HeLx to Kubernetes.
 
-![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.5](https://img.shields.io/badge/AppVersion-1.4.5-informational?style=flat-square)
+![Version: 0.8.3](https://img.shields.io/badge/Version-0.8.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.5](https://img.shields.io/badge/AppVersion-1.4.5-informational?style=flat-square)
 
 HeLx puts the most advanced analytical scientific models at investigator’s finger tips using equally advanced cloud native, container orchestrated, distributed computing systems. HeLx can be applied in many domains. Its ability to empower researchers to leverage advanced analytical tools without installation or other infrastructure concerns has broad reaching benefits.
 

--- a/helx/README.md
+++ b/helx/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying HeLx to Kubernetes.
 
-![Version: 0.8.3](https://img.shields.io/badge/Version-0.8.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.5](https://img.shields.io/badge/AppVersion-1.4.5-informational?style=flat-square)
+![Version: 0.8.4](https://img.shields.io/badge/Version-0.8.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.6](https://img.shields.io/badge/AppVersion-1.4.6-informational?style=flat-square)
 
 HeLx puts the most advanced analytical scientific models at investigator’s finger tips using equally advanced cloud native, container orchestrated, distributed computing systems. HeLx can be applied in many domains. Its ability to empower researchers to leverage advanced analytical tools without installation or other infrastructure concerns has broad reaching benefits.
 

--- a/helx/charts/appstore/Chart.yaml
+++ b/helx/charts/appstore/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.29
+version: 0.1.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helx/charts/appstore/Chart.yaml
+++ b/helx/charts/appstore/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.30
+version: 0.1.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.20
+appVersion: 1.0.21

--- a/helx/charts/appstore/Chart.yaml
+++ b/helx/charts/appstore/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.19
+appVersion: 1.0.20

--- a/helx/charts/appstore/README.md
+++ b/helx/charts/appstore/README.md
@@ -1,6 +1,6 @@
 # appstore
 
-![Version: 0.1.30](https://img.shields.io/badge/Version-0.1.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.19](https://img.shields.io/badge/AppVersion-1.0.19-informational?style=flat-square)
+![Version: 0.1.30](https://img.shields.io/badge/Version-0.1.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.20](https://img.shields.io/badge/AppVersion-1.0.20-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -50,6 +50,7 @@ A Helm chart for Kubernetes
 | global.stdnfsPvc | string | `"stdnfs"` | the name of the PVC to use for user's files |
 | image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | image.repository | string | `"helxplatform/appstore"` | repository where image is located |
+| image.tag | string | `"develop-v1.1.77"` |  |
 | imagePullSecrets | list | `[]` | credentials for a private repo |
 | irods.BRAINI_RODS | string | `""` |  |
 | irods.IROD_COLLECTIONS | string | `""` |  |

--- a/helx/charts/appstore/README.md
+++ b/helx/charts/appstore/README.md
@@ -1,6 +1,6 @@
 # appstore
 
-![Version: 0.1.29](https://img.shields.io/badge/Version-0.1.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.19](https://img.shields.io/badge/AppVersion-1.0.19-informational?style=flat-square)
+![Version: 0.1.30](https://img.shields.io/badge/Version-0.1.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.19](https://img.shields.io/badge/AppVersion-1.0.19-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -16,7 +16,7 @@ A Helm chart for Kubernetes
 | appStorage.storageClass | string | `nil` |  |
 | appStorage.storageSize | string | `"2Gi"` |  |
 | apps.DICOMGH_GOOGLE_CLIENT_ID | string | `""` |  |
-| appstoreEntrypointArgs | string | `"bin/appstore updatedb cat && bin/appstore createsuperuser && bin/appstore manageauthorizedusers cat && bin/appstore run cat"` |  |
+| appstoreEntrypointArgs | string | `"make appstore.start brand="` | Allow for a custom entrypoint command via the values file.  The brand is set via the djangoSettings value, therefor 'brand=' needs to be at the end of this command. |
 | createHomeDirs | bool | `true` | Create Home directories for users |
 | db.name | string | `"appstore"` |  |
 | django.ALLOW_DJANGO_LOGIN | string | `""` | show Django log in fields (true | false) |
@@ -25,10 +25,11 @@ A Helm chart for Kubernetes
 | django.APPSTORE_DJANGO_USERNAME | string | `"admin"` |  |
 | django.AUTHORIZED_USERS | string | `""` | user emails for oauth providers |
 | django.DOCKSTORE_APPS_BRANCH | string | `"master"` | Defaults to "master". Specify "develop" to switch. |
-| django.EMAIL_HOST_PASSWORD | string | `""` |  |
-| django.EMAIL_HOST_USER | string | `""` |  |
-| django.IMAGE_DOWNLOAD_URL | string | `""` |  |
+| django.EMAIL_HOST_PASSWORD | string | `""` | password of account to use for outgoing emails |
+| django.EMAIL_HOST_USER | string | `""` | email of account to use for outgoing emails |
+| django.IMAGE_DOWNLOAD_URL | string | `""` | Specify URL to use for the "Image Download" link on the top part of website. |
 | django.REMOVE_AUTHORIZED_USERS | string | `""` | user emails to remove from an already-existing database |
+| django.SESSION_IDLE_TIMEOUT | int | `3600` | idle timeout for user web session |
 | django.WHITELIST_REDIRECT | string | `"true"` | redirect unauthorized users of return a 403 |
 | django.oauth.GITHUB_CLIENT_ID | string | `""` |  |
 | django.oauth.GITHUB_KEY | string | `""` |  |

--- a/helx/charts/appstore/README.md
+++ b/helx/charts/appstore/README.md
@@ -1,6 +1,6 @@
 # appstore
 
-![Version: 0.1.30](https://img.shields.io/badge/Version-0.1.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.20](https://img.shields.io/badge/AppVersion-1.0.20-informational?style=flat-square)
+![Version: 0.1.31](https://img.shields.io/badge/Version-0.1.31-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.21](https://img.shields.io/badge/AppVersion-1.0.21-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -16,7 +16,7 @@ A Helm chart for Kubernetes
 | appStorage.storageClass | string | `nil` |  |
 | appStorage.storageSize | string | `"2Gi"` |  |
 | apps.DICOMGH_GOOGLE_CLIENT_ID | string | `""` |  |
-| appstoreEntrypointArgs | string | `"make appstore.start brand="` | Allow for a custom entrypoint command via the values file.  The brand is set via the djangoSettings value, therefor 'brand=' needs to be at the end of this command. |
+| appstoreEntrypointArgs | string | `"make appstore.start"` | Allow for a custom entrypoint command via the values file.  The brand is set via the djangoSettings value, therefor 'brand=' needs to be at the end of this command. |
 | createHomeDirs | bool | `true` | Create Home directories for users |
 | db.name | string | `"appstore"` |  |
 | django.ALLOW_DJANGO_LOGIN | string | `""` | show Django log in fields (true | false) |
@@ -50,7 +50,7 @@ A Helm chart for Kubernetes
 | global.stdnfsPvc | string | `"stdnfs"` | the name of the PVC to use for user's files |
 | image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | image.repository | string | `"helxplatform/appstore"` | repository where image is located |
-| image.tag | string | `"develop-v1.1.77"` |  |
+| image.tag | string | `"develop-v1.1.81"` |  |
 | imagePullSecrets | list | `[]` | credentials for a private repo |
 | irods.BRAINI_RODS | string | `""` |  |
 | irods.IROD_COLLECTIONS | string | `""` |  |

--- a/helx/charts/appstore/templates/configmap.yaml
+++ b/helx/charts/appstore/templates/configmap.yaml
@@ -23,3 +23,4 @@ data:
   SAML2_AUTH_ASSERTION_URL: "{{ .Values.django.saml2auth.ASSERTION_URL }}"
   SAML2_AUTH_ENTITY_ID: "{{ .Values.django.saml2auth.ENTITY_ID }}"
   IMAGE_DOWNLOAD_URL: "{{ .Values.django.IMAGE_DOWNLOAD_URL }}"
+  DJANGO_SESSION_IDLE_TIMEOUT: "{{ .Values.django.SESSION_IDLE_TIMEOUT }}"

--- a/helx/charts/appstore/templates/deployment.yaml
+++ b/helx/charts/appstore/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ['/bin/bash', '-c']
-        args: ["{{ .Values.appstoreEntrypointArgs}}"]
+        args: ["{{ .Values.appstoreEntrypointArgs }}{{ .Values.djangoSettings }}"]
         # For debugging when things go wrong.
         # args: ["while true; do date; sleep 5; done"]
         resources:

--- a/helx/charts/appstore/templates/deployment.yaml
+++ b/helx/charts/appstore/templates/deployment.yaml
@@ -46,6 +46,11 @@ spec:
             configMapKeyRef:
               key: DJANGO_SETTINGS_MODULE
               name: {{ include "appstore.fullname" . }}-env
+        - name: DJANGO_SESSION_IDLE_TIMEOUT
+          valueFrom:
+            configMapKeyRef:
+              key: DJANGO_SESSION_IDLE_TIMEOUT
+              name: {{ include "appstore.fullname" . }}-env
         - name: ALLOW_DJANGO_LOGIN
           valueFrom:
             configMapKeyRef:

--- a/helx/charts/appstore/templates/deployment.yaml
+++ b/helx/charts/appstore/templates/deployment.yaml
@@ -30,9 +30,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ['/bin/bash', '-c']
-        args: ["{{ .Values.appstoreEntrypointArgs }}{{ .Values.djangoSettings }}"]
-        # For debugging when things go wrong.
-        # args: ["while true; do date; sleep 5; done"]
+        args: ["{{ .Values.appstoreEntrypointArgs }}"]
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         env:

--- a/helx/charts/appstore/values.yaml
+++ b/helx/charts/appstore/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- pull policy
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: develop-v1.1.77
+  tag: develop-v1.1.81
 
 # -- credentials for a private repo
 imagePullSecrets: []
@@ -66,7 +66,7 @@ djangoSettings: cat
 # -- Allow for a custom entrypoint command via the values file.  The brand is
 # set via the djangoSettings value, therefor 'brand=' needs to be at the end of
 # this command.
-appstoreEntrypointArgs: "make appstore.start brand="
+appstoreEntrypointArgs: "make appstore.start"
 
 django:
   # -- user emails for oauth providers

--- a/helx/charts/appstore/values.yaml
+++ b/helx/charts/appstore/values.yaml
@@ -80,11 +80,16 @@ django:
   ALLOW_DJANGO_LOGIN: ""
   # -- show SAML log in fields (true | false)
   ALLOW_SAML_LOGIN: ""
+  # -- email of account to use for outgoing emails
   EMAIL_HOST_USER: ""
+  # -- password of account to use for outgoing emails
   EMAIL_HOST_PASSWORD: ""
   # -- redirect unauthorized users of return a 403
   WHITELIST_REDIRECT: "true"
+  # -- Specify URL to use for the "Image Download" link on the top part of website.
   IMAGE_DOWNLOAD_URL: ""
+  # -- idle timeout for user web session
+  SESSION_IDLE_TIMEOUT: 3600
   oauth:
     # -- oauth providers separated by commas (google, github)
     OAUTH_PROVIDERS: ""

--- a/helx/charts/appstore/values.yaml
+++ b/helx/charts/appstore/values.yaml
@@ -63,7 +63,9 @@ ambassador:
 
 # -- set the theme for appstore (cat, braini, restartr, scidas)
 djangoSettings: cat
-# Allow for a custom entrypoint command via the values file, make sure the djangoSettings and brand in entry are the same.
+# -- Allow for a custom entrypoint command via the values file.  The brand is
+# set via the djangoSettings value, therefor 'brand=' needs to be at the end of
+# this command.
 appstoreEntrypointArgs: "make appstore.start brand="
 
 django:

--- a/helx/charts/appstore/values.yaml
+++ b/helx/charts/appstore/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- pull policy
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  # tag: 1.0.2
+  tag: develop-v1.1.77
 
 # -- credentials for a private repo
 imagePullSecrets: []

--- a/helx/charts/appstore/values.yaml
+++ b/helx/charts/appstore/values.yaml
@@ -64,7 +64,7 @@ ambassador:
 # -- set the theme for appstore (cat, braini, restartr, scidas)
 djangoSettings: cat
 # Allow for a custom entrypoint command via the values file, make sure the djangoSettings and brand in entry are the same.
-appstoreEntrypointArgs: "bin/appstore updatedb cat && bin/appstore createsuperuser && bin/appstore manageauthorizedusers cat && bin/appstore run cat"
+appstoreEntrypointArgs: "make appstore.start brand="
 
 django:
   # -- user emails for oauth providers


### PR DESCRIPTION
Added value for appstore session time out to chart and set to default of one hour. Also changed the entrypoint command for appstore so it will work with new image. Tested and works for me.  PR has been updated for newer appstore image that doesn't need the 'brand' specified in appstore entrypoint command.