### PR TITLE
ambassador chart updated to use ambassador_id

### DIFF
--- a/helx/Chart.yaml
+++ b/helx/Chart.yaml
@@ -23,10 +23,10 @@ appVersion: 1.4.14
 dependencies:
   - name: ambassador
     condition: ambassador.enabled
-    version: 0.1.6
+    version: 0.1.7
   - name: appstore
     condition: appstore.enabled
-    version: 0.1.36
+    version: 0.1.37
   - name: backup-pvc-cronjob
     condition: backup-pvc-cronjob.enabled
     version: 0.1.0

--- a/helx/charts/ambassador/Chart.yaml
+++ b/helx/charts/ambassador/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: ambassador
-version: 0.1.6
+version: 0.1.7
 appVersion: 1.12.0

--- a/helx/charts/ambassador/README.md
+++ b/helx/charts/ambassador/README.md
@@ -1,6 +1,6 @@
 # ambassador
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![AppVersion: 1.12.0](https://img.shields.io/badge/AppVersion-1.12.0-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![AppVersion: 1.12.0](https://img.shields.io/badge/AppVersion-1.12.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -10,6 +10,7 @@ A Helm chart for Kubernetes
 |-----|------|---------|-------------|
 | adminservice.type | string | `"ClusterIP"` |  |
 | fullnameOverride | string | `""` |  |
+| global.ambassador_id | string | `"ambassador-helx"` | Specify the Ambassador ID (useful if multiple Ambassadors are deployed to the same cluster). |
 | global.ambassador_service_name | string | `"ambassador"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"docker.io/datawire/ambassador"` |  |

--- a/helx/charts/ambassador/templates/ambassador-module.yaml
+++ b/helx/charts/ambassador/templates/ambassador-module.yaml
@@ -1,0 +1,9 @@
+apiVersion: getambassador.io/v2
+kind:  Module
+metadata:
+  name:  ambassador
+spec:
+# See https://www.getambassador.io/docs/latest/topics/running/ambassador/
+# Use ambassador_id only if you are using multiple ambassadors in the same cluster.
+# See below for more information.
+  ambassador_id: "{{ .Values.global.ambassador_id }}"

--- a/helx/charts/ambassador/templates/deployment.yaml
+++ b/helx/charts/ambassador/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{ if .Values.global.ambassador_id }}
+        - name: AMBASSADOR_ID
+          value: {{ .Values.global.ambassador_id }}
+        {{- end }}
         - name: AMBASSADOR_SINGLE_NAMESPACE
           value: "true"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/helx/charts/ambassador/values.yaml
+++ b/helx/charts/ambassador/values.yaml
@@ -36,3 +36,6 @@ resources:
 
 global:
   ambassador_service_name: ambassador
+  # -- Specify the Ambassador ID (useful if multiple Ambassadors are deployed to
+  # the same cluster).
+  ambassador_id: ambassador-helx

--- a/helx/charts/appstore/Chart.yaml
+++ b/helx/charts/appstore/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.36
+version: 0.1.37
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.24
+appVersion: 1.0.26

--- a/helx/charts/appstore/README.md
+++ b/helx/charts/appstore/README.md
@@ -1,6 +1,6 @@
 # appstore
 
-![Version: 0.1.36](https://img.shields.io/badge/Version-0.1.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.24](https://img.shields.io/badge/AppVersion-1.0.24-informational?style=flat-square)
+![Version: 0.1.37](https://img.shields.io/badge/Version-0.1.37-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.26](https://img.shields.io/badge/AppVersion-1.0.26-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -10,14 +10,13 @@ A Helm chart for Kubernetes
 |-----|------|---------|-------------|
 | ACCOUNT_DEFAULT_HTTP_PROTOCOL | string | `"http"` | Choose http or https for the protocol that is used by external users to access the appstore web service. |
 | affinity | object | `{}` |  |
-| ambassador.flag | bool | `true` | register appstore with ambassador flag: <True or False> |
-| ambassador.id | string | `nil` | specify the id of the ambassador for Tycho-launched services. |
+| ambassador.flag | bool | `true` | specify the id of the ambassador for Tycho-launched services. id: -- register appstore with ambassador flag: <True or False> |
 | appStorage.claimName | string | `nil` |  |
 | appStorage.existingClaim | bool | `false` |  |
 | appStorage.storageClass | string | `nil` |  |
 | appStorage.storageSize | string | `"2Gi"` |  |
 | apps.DICOMGH_GOOGLE_CLIENT_ID | string | `""` |  |
-| appstoreEntrypointArgs | string | `"make appstore.start"` | Allow for a custom entrypoint command via the values file. |
+| appstoreEntrypointArgs | string | `"make start"` | Allow for a custom entrypoint command via the values file. |
 | createHomeDirs | bool | `true` | Create Home directories for users |
 | db.name | string | `"appstore"` |  |
 | django.ALLOW_DJANGO_LOGIN | string | `""` | show Django log in fields (true | false) |
@@ -48,6 +47,7 @@ A Helm chart for Kubernetes
 | djangoSettings | string | `"cat"` | set the theme for appstore (cat, braini, restartr, scidas) |
 | extraEnv | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
+| global.ambassador_id | string | `"ambassador-helx"` | specify the id of the ambassador for Tycho-launched services. |
 | global.stdnfsPvc | string | `"stdnfs"` | the name of the PVC to use for user's files |
 | image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | image.repository | string | `"helxplatform/appstore"` | repository where image is located |

--- a/helx/charts/appstore/templates/deployment.yaml
+++ b/helx/charts/appstore/templates/deployment.yaml
@@ -129,7 +129,7 @@ spec:
             secretKeyRef:
               key: APPSTORE_DJANGO_PASSWORD
               name: {{ include "appstore.fullname" . }}
-        {{ if .Values.ambassador.id }}
+        {{ if .Values.global.ambassador_id }}
         - name: AMBASSADOR_ID
           valueFrom:
             secretKeyRef:

--- a/helx/charts/appstore/templates/secrets.yaml
+++ b/helx/charts/appstore/templates/secrets.yaml
@@ -65,6 +65,6 @@ data:
   IROD_COLLECTIONS: {{ .Values.irods.IROD_COLLECTIONS | b64enc }}
   IROD_ZONE: {{ .Values.irods.IROD_ZONE | b64enc }}
   {{- end }}
-  {{- if .Values.ambassador.id }}
-  AMBASSADOR_ID: {{ .Values.ambassador.id | b64enc }}
+  {{- if .Values.global.ambassador_id }}
+  AMBASSADOR_ID: {{ .Values.global.ambassador_id | b64enc }}
   {{- end }}

--- a/helx/charts/appstore/templates/service.yaml
+++ b/helx/charts/appstore/templates/service.yaml
@@ -13,6 +13,7 @@ metadata:
       name:  appstore-mapping
       prefix: /
       service: {{ include "appstore.fullname" . }}:8000
+      ambassador_id: {{ .Values.global.ambassador_id }}
       timeout_ms: 300000
       idle_timeout_ms: 500000
       connect_timeout_ms: 500000

--- a/helx/charts/appstore/values.yaml
+++ b/helx/charts/appstore/values.yaml
@@ -58,15 +58,13 @@ db:
   name: appstore
 
 ambassador:
-   # -- specify the id of the ambassador for Tycho-launched services.
-   id:
    # -- register appstore with ambassador flag: <True or False>
    flag: true
 
 # -- set the theme for appstore (cat, braini, restartr, scidas)
 djangoSettings: cat
 # -- Allow for a custom entrypoint command via the values file.
-appstoreEntrypointArgs: "make appstore.start"
+appstoreEntrypointArgs: "make start"
 
 django:
   # -- user emails for oauth providers
@@ -149,6 +147,8 @@ extraEnv: {}
 global:
   # -- the name of the PVC to use for user's files
   stdnfsPvc: stdnfs
+  # -- specify the id of the ambassador for Tycho-launched services.
+  ambassador_id: ambassador-helx
 
 # -- Set to true, when using blackbalsam.
 useSparkServiceAccount: true


### PR DESCRIPTION
Module resource added for ambassador to go along with the ambassador_id setting.  Added ambassador_id to annotations for ambassador service.  Created a global variable for ambassador_id to be used by ambassador and appstore.  Updated the entrypoint for appstore to go with new makefile in the image.  I was able to launch app on my test cluster so this should all be good to go.  Will need to test with another ambassador deployed in the cluster to see if this really solves the initial problem.