### PR TITLE
Fixing string quotation for appstore extraEnv values

### DIFF
--- a/helx/Chart.yaml
+++ b/helx/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.8.15
+version: 0.8.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helx/Chart.yaml
+++ b/helx/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.1.8
   - name: appstore
     condition: appstore.enabled
-    version: 0.1.38
+    version: 0.1.39
   - name: backup-pvc-cronjob
     condition: backup-pvc-cronjob.enabled
     version: 0.1.0

--- a/helx/README.md
+++ b/helx/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying HeLx to Kubernetes.
 
-![Version: 0.8.15](https://img.shields.io/badge/Version-0.8.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.14](https://img.shields.io/badge/AppVersion-1.4.14-informational?style=flat-square)
+![Version: 0.8.16](https://img.shields.io/badge/Version-0.8.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.14](https://img.shields.io/badge/AppVersion-1.4.14-informational?style=flat-square)
 
 HeLx puts the most advanced analytical scientific models at investigator’s finger tips using equally advanced cloud native, container orchestrated, distributed computing systems. HeLx can be applied in many domains. Its ability to empower researchers to leverage advanced analytical tools without installation or other infrastructure concerns has broad reaching benefits.
 

--- a/helx/charts/appstore/Chart.yaml
+++ b/helx/charts/appstore/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.38
+version: 0.1.39
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helx/charts/appstore/README.md
+++ b/helx/charts/appstore/README.md
@@ -1,6 +1,6 @@
 # appstore
 
-![Version: 0.1.38](https://img.shields.io/badge/Version-0.1.38-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.26](https://img.shields.io/badge/AppVersion-1.0.26-informational?style=flat-square)
+![Version: 0.1.39](https://img.shields.io/badge/Version-0.1.39-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.26](https://img.shields.io/badge/AppVersion-1.0.26-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/helx/charts/appstore/templates/deployment.yaml
+++ b/helx/charts/appstore/templates/deployment.yaml
@@ -268,7 +268,7 @@ spec:
               name: {{ include "appstore.fullname" . }}
         {{- range $key, $value := .Values.extraEnv }}
         - name: {{ $key }}
-          value: {{ $value }}
+          value: {{ $value | quote }}
         {{- end }}
         - name: CREATE_HOME_DIRS
           value: "{{- .Values.createHomeDirs }}"
@@ -284,10 +284,6 @@ spec:
         {{- end }}
         - name: SHARED_DIR
           value: "{{ .Values.shared_dir }}"
-        {{- range $key, $value := .Values.extraEnv }}
-        - name: {{ $key }}
-          value: {{ $value }}
-        {{- end }}
         - name: IMAGE_DOWNLOAD_URL
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
This change fixes a bug in which extraEnvs were not quoted. This caused
the helm templates to render string values "TRUE" and "FALSE" as boolean
values.

It also removes a duplicated interpolation of the extraEnv values in the
appstore deployment template that prevented them from rendering.