### PR TITLE
added monitoring chart to replace helx-monitoring

### DIFF
--- a/helx/Chart.lock
+++ b/helx/Chart.lock
@@ -14,6 +14,9 @@ dependencies:
 - name: image-utils
   repository: ""
   version: 0.1.0
+- name: monitoring
+  repository: ""
+  version: 0.1.0
 - name: nfs-server
   repository: ""
   version: 0.2.5
@@ -32,5 +35,5 @@ dependencies:
 - name: tycho-api
   repository: https://helxplatform.github.io/helm-charts/
   version: 0.2-dev
-digest: sha256:0f8e84fadee4d5b11b15170508a3325f89f109716118787fd16470b1c6db77be
-generated: "2021-10-18T11:50:39.836415-04:00"
+digest: sha256:24d0dd3d2cddf01ebaec91e0863166f8156ed9f5a49bea733f451224e7f13178
+generated: "2021-10-29T15:51:07.799635-04:00"

--- a/helx/Chart.yaml
+++ b/helx/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.2
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.5.1
+appVersion: 1.6.0
 
 dependencies:
   - name: ambassador
@@ -36,6 +36,9 @@ dependencies:
     version: 0.1.6
   - name: image-utils
     condition: image-utils.enabled
+    version: 0.1.0
+  - name: monitoring
+    condition: monitoring.enabled
     version: 0.1.0
   - name: nfs-server
     condition: nfs-server.enabled

--- a/helx/README.md
+++ b/helx/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying HeLx to Kubernetes.
 
-![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.1](https://img.shields.io/badge/AppVersion-1.5.1-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 HeLx puts the most advanced analytical scientific models at investigator’s finger tips using equally advanced cloud native, container orchestrated, distributed computing systems. HeLx can be applied in many domains. Its ability to empower researchers to leverage advanced analytical tools without installation or other infrastructure concerns has broad reaching benefits.
 
@@ -84,6 +84,7 @@ You can view the README.md files for each subchart to see the variables that exi
 | global.tycho_api_service_name | string | `"helx-tycho-api"` |  |
 | helx-monitoring.enabled | bool | `false` | enable/disable deployment of loki-stack and cost-analyzer |
 | image-utils.enabled | bool | `false` | enable/disable deployment of image-utils (imagepullsecret-patcher and imagepuller) |
+| monitoring.enabled | bool | `false` | enable/disable deployment of Kubernetes monitoring charts (kube-prometheus-stack, cost-analyzer, etc.) |
 | nfs-server.enabled | bool | `true` | enable/disable deployment of nfs-server |
 | nfsrods.enabled | bool | `false` | enable/disable deployment of nfsrods |
 | nginx.enabled | bool | `true` | enable/disable deployment of nginx |

--- a/helx/charts/monitoring/.helmignore
+++ b/helx/charts/monitoring/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helx/charts/monitoring/Chart.lock
+++ b/helx/charts/monitoring/Chart.lock
@@ -1,0 +1,18 @@
+dependencies:
+- name: cost-analyzer
+  repository: https://kubecost.github.io/cost-analyzer/
+  version: 1.87.0
+- name: kube-prometheus-stack
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 19.0.0
+- name: loki
+  repository: https://grafana.github.io/helm-charts
+  version: 2.6.0
+- name: promtail
+  repository: https://grafana.github.io/helm-charts
+  version: 3.8.1
+- name: falco
+  repository: https://falcosecurity.github.io/charts
+  version: 1.16.0
+digest: sha256:e03f43a264033db8e170057e6c2817e7861a8ca79bc0349a1872a80ec683c7ef
+generated: "2021-10-07T14:52:04.725096-04:00"

--- a/helx/charts/monitoring/Chart.yaml
+++ b/helx/charts/monitoring/Chart.yaml
@@ -1,0 +1,34 @@
+apiVersion: v2
+name: monitoring
+description: Monitoring stack for k8s clusters
+type: application
+# INTERNAL USE ONLY, don't bother incrementing
+version: 0.1.0
+appVersion: 0.1.0
+
+dependencies:
+  # Kubecost, for estimating costs of pods
+  - name: cost-analyzer
+    condition: cost-analyzer.enabled
+    repository: https://kubecost.github.io/cost-analyzer/
+    version: 1.87.0
+  # prometheus-operator, grafana, and alertmanager
+  - name: kube-prometheus-stack
+    condition: kube-prometheus-stack.enabled
+    repository: https://prometheus-community.github.io/helm-charts
+    version: 19.0.0
+  # Log storage/search
+  - name: loki
+    condition: loki.enabled
+    repository: https://grafana.github.io/helm-charts
+    version: 2.6.0
+  # Log collection
+  - name: promtail
+    condition: promtail.enabled
+    repository: https://grafana.github.io/helm-charts
+    version: 3.8.1
+  # Watches syscalls for suspicious behavior
+  - name: falco
+    condition: falco.enabled
+    repository: https://falcosecurity.github.io/charts
+    version: 1.16.0

--- a/helx/charts/monitoring/README.md
+++ b/helx/charts/monitoring/README.md
@@ -1,0 +1,101 @@
+# monitoring
+
+Monitoring stack for k8s clusters
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+
+# Monitoring
+
+This folder contains the monitoring stack for k8s clusters.
+
+The following components are all included:
+
+- https://www.kubecost.com/
+- https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/README.md
+- https://grafana.com/docs/loki/latest/
+- https://grafana.com/docs/loki/latest/clients/promtail/
+
+## Installing
+
+```
+kubectl create ns monitoring
+
+helm upgrade --install -n monitoring monitoring . -f your-values.yaml
+```
+
+(replace the values file with your environment if different)
+
+## Creating a new monitored service
+
+If you want to monitor a new service, create a ServiceMonitor in the templates folder similar to one of the existing ones: https://prometheus-operator.dev/docs/operator/api/#servicemonitor
+
+After a `helm upgrade`, prometheus-operator will start scraping metrics from that service and storing them, visible in grafana. You can then create alerts based on changes in those metrics by creating an AlertmanagerConfig: https://prometheus-operator.dev/docs/operator/api/#alertmanagerconfig
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://falcosecurity.github.io/charts | falco | 1.16.0 |
+| https://grafana.github.io/helm-charts | loki | 2.6.0 |
+| https://grafana.github.io/helm-charts | promtail | 3.8.1 |
+| https://kubecost.github.io/cost-analyzer/ | cost-analyzer | 1.87.0 |
+| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack | 19.0.0 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| basicauth-creds | string | `nil` |  |
+| cost-analyzer.enabled | bool | `true` |  |
+| cost-analyzer.global.grafana.domainName | string | `"monitoring-grafana.monitoring"` |  |
+| cost-analyzer.global.grafana.enabled | bool | `false` |  |
+| cost-analyzer.global.notifications.alertmanager.enabled | bool | `false` |  |
+| cost-analyzer.global.notifications.alertmanager.fqdn | string | `"http://monitoring-kube-prometheus-alertmanager.monitoring:9093"` |  |
+| cost-analyzer.global.prometheus.enabled | bool | `false` |  |
+| cost-analyzer.global.prometheus.fqdn | string | `"http://monitoring-kube-prometheus-prometheus.monitoring:9090"` |  |
+| cost-analyzer.prometheus.kube-state-metrics.disabled | bool | `true` |  |
+| cost-analyzer.prometheus.kube-state-metrics.enabled | bool | `false` |  |
+| cost-analyzer.prometheus.kube-state-metrics.rbac.create | bool | `false` |  |
+| cost-analyzer.readonly | bool | `true` |  |
+| cost-analyzer.reporting.errorReporting | bool | `false` |  |
+| cost-analyzer.reporting.logCollection | bool | `false` |  |
+| cost-analyzer.reporting.productAnalytics | bool | `false` |  |
+| cost-analyzer.reporting.valuesReporting | bool | `false` |  |
+| falco.enabled | bool | `true` |  |
+| falco.falcosidekick.config.alertmanager.hostport | string | `"http://alertmanager-operated.monitoring:9093"` |  |
+| falco.falcosidekick.config.alertmanager.minimumpriority | string | `"error"` |  |
+| falco.falcosidekick.enabled | bool | `true` |  |
+| kube-prometheus-stack.alertmanager.enabled | bool | `true` |  |
+| kube-prometheus-stack.enabled | bool | `true` |  |
+| kube-prometheus-stack.grafana.additionalDataSources[0].access | string | `"proxy"` |  |
+| kube-prometheus-stack.grafana.additionalDataSources[0].name | string | `"Loki"` |  |
+| kube-prometheus-stack.grafana.additionalDataSources[0].type | string | `"loki"` |  |
+| kube-prometheus-stack.grafana.additionalDataSources[0].url | string | `"http://monitoring-loki.monitoring:3100"` |  |
+| kube-prometheus-stack.grafana.additionalDataSources[0].version | int | `1` |  |
+| kube-prometheus-stack.grafana.enabled | bool | `true` |  |
+| kube-prometheus-stack.prometheus-node-exporter.resources.limits.cpu | string | `"500m"` |  |
+| kube-prometheus-stack.prometheus-node-exporter.resources.limits.memory | string | `"256Mi"` |  |
+| kube-prometheus-stack.prometheus-node-exporter.resources.requests.cpu | string | `"250m"` |  |
+| kube-prometheus-stack.prometheus-node-exporter.resources.requests.memory | string | `"128Mi"` |  |
+| kube-prometheus-stack.prometheus.prometheusSpec.resources.limits.cpu | string | `"1500m"` |  |
+| kube-prometheus-stack.prometheus.prometheusSpec.resources.limits.memory | string | `"2000Mi"` |  |
+| kube-prometheus-stack.prometheus.prometheusSpec.resources.requests.cpu | string | `"1500m"` |  |
+| kube-prometheus-stack.prometheus.prometheusSpec.resources.requests.memory | string | `"2000Mi"` |  |
+| kube-prometheus-stack.prometheus.prometheusSpec.ruleSelector | object | `{}` |  |
+| kube-prometheus-stack.prometheus.prometheusSpec.ruleSelectorNilUsesHelmValues | bool | `false` |  |
+| kube-prometheus-stack.prometheus.prometheusSpec.serviceMonitorSelector | object | `{}` |  |
+| kube-prometheus-stack.prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues | bool | `false` |  |
+| kube-prometheus-stack.prometheusOperator.enabled | bool | `true` |  |
+| loki.config.limits_config.retention_period | string | `"90d"` |  |
+| loki.enabled | bool | `true` |  |
+| loki.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
+| loki.persistence.enabled | bool | `true` |  |
+| loki.persistence.size | string | `"10Gi"` |  |
+| loki.replicas | int | `3` |  |
+| loki.serviceMonitor.enabled | bool | `true` |  |
+| promtail.config.lokiAddress | string | `"http://monitoring-loki.monitoring:3100/loki/api/v1/push"` |  |
+| promtail.enabled | bool | `true` |  |
+| promtail.rbac.pspEnabled | bool | `true` |  |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/helx/charts/monitoring/README.md.gotmpl
+++ b/helx/charts/monitoring/README.md.gotmpl
@@ -1,0 +1,39 @@
+{{ template "chart.header" . }}
+{{ template "chart.description" . }}
+
+{{ template "chart.versionBadge" .  }}{{ template "chart.typeBadge" .  }}{{ template "chart.appVersionBadge" .  }}
+
+# Monitoring
+
+This folder contains the monitoring stack for k8s clusters.
+
+The following components are all included:
+
+- https://www.kubecost.com/
+- https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/README.md
+- https://grafana.com/docs/loki/latest/
+- https://grafana.com/docs/loki/latest/clients/promtail/
+
+
+## Installing
+
+```
+kubectl create ns monitoring
+
+helm upgrade --install -n monitoring monitoring . -f your-values.yaml
+```
+
+(replace the values file with your environment if different)
+
+## Creating a new monitored service
+
+If you want to monitor a new service, create a ServiceMonitor in the templates folder similar to one of the existing ones: https://prometheus-operator.dev/docs/operator/api/#servicemonitor
+
+After a `helm upgrade`, prometheus-operator will start scraping metrics from that service and storing them, visible in grafana. You can then create alerts based on changes in those metrics by creating an AlertmanagerConfig: https://prometheus-operator.dev/docs/operator/api/#alertmanagerconfig
+
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/helx/charts/monitoring/templates/NOTES.txt
+++ b/helx/charts/monitoring/templates/NOTES.txt
@@ -1,0 +1,10 @@
+******WARNING******
+
+After running an upgrade, you must manually edit the monitoring-falco ConfigMap
+to fix the falcosidekick to be "http://monitoring-falcosidekick:2801"
+
+    kubectl edit configmap monitoring-falco -n monitoring
+
+This is due to a bug that has no current workaround: https://github.com/falcosecurity/charts/issues/280
+
+******WARNING******

--- a/helx/charts/monitoring/templates/_helpers.tpl
+++ b/helx/charts/monitoring/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "monitoring.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "monitoring.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "monitoring.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "monitoring.labels" -}}
+helm.sh/chart: {{ include "monitoring.chart" . }}
+{{ include "monitoring.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "monitoring.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "monitoring.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "monitoring.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "monitoring.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helx/charts/monitoring/templates/basicauth_secret.yaml
+++ b/helx/charts/monitoring/templates/basicauth_secret.yaml
@@ -1,0 +1,9 @@
+{{ if .Values.basicAuthCreds }}
+# Used to protect kubecost, prometheus, and alertmanager which don't natively support auth.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "monitoring-basicauth"
+data:
+  auth: "{{ .Values.basicAuthCreds | b64enc }}"
+{{- end }}

--- a/helx/charts/monitoring/templates/kubecost_prometheusrule.yaml
+++ b/helx/charts/monitoring/templates/kubecost_prometheusrule.yaml
@@ -1,0 +1,53 @@
+# Used to scrape metrics from kubecost
+# See https://docs.kubecost.com/custom-prom.html
+# and https://prometheus-operator.dev/docs/operator/api/#prometheusrulespec
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "monitoring.labels" . | nindent 4 }}
+    release: "{{ .Release.Name }}"
+  name: "{{ .Release.Name }}-kubecost"
+  namespace: monitoring
+spec:
+  groups:
+    - name: CPU
+      rules:
+        - expr: sum(rate(container_cpu_usage_seconds_total{container_name!=""}[5m]))
+          record: cluster:cpu_usage:rate5m
+        - expr: rate(container_cpu_usage_seconds_total{container_name!=""}[5m])
+          record: cluster:cpu_usage_nosum:rate5m
+        - expr: avg(irate(container_cpu_usage_seconds_total{container_name!="POD", container_name!=""}[5m])) by (container_name,pod_name,namespace)
+          record: kubecost_container_cpu_usage_irate
+        - expr: sum(container_memory_working_set_bytes{container_name!="POD",container_name!=""}) by (container_name,pod_name,namespace)
+          record: kubecost_container_memory_working_set_bytes
+        - expr: sum(container_memory_working_set_bytes{container_name!="POD",container_name!=""})
+          record: kubecost_cluster_memory_working_set_bytes
+    - name: Savings
+      rules:
+        - expr: sum(avg(kube_pod_owner{owner_kind!="DaemonSet"}) by (pod) * sum(container_cpu_allocation) by (pod))
+          record: kubecost_savings_cpu_allocation
+          labels:
+            daemonset: "false"
+        - expr: sum(avg(kube_pod_owner{owner_kind="DaemonSet"}) by (pod) * sum(container_cpu_allocation) by (pod)) / sum(kube_node_info)
+          record: kubecost_savings_cpu_allocation
+          labels:
+            daemonset: "true"
+        - expr: sum(avg(kube_pod_owner{owner_kind!="DaemonSet"}) by (pod) * sum(container_memory_allocation_bytes) by (pod))
+          record: kubecost_savings_memory_allocation_bytes
+          labels:
+            daemonset: "false"
+        - expr: sum(avg(kube_pod_owner{owner_kind="DaemonSet"}) by (pod) * sum(container_memory_allocation_bytes) by (pod)) / sum(kube_node_info)
+          record: kubecost_savings_memory_allocation_bytes
+          labels:
+            daemonset: "true"
+        - expr: label_replace(sum(kube_pod_status_phase{phase="Running",namespace!="kube-system"} > 0) by (pod, namespace), "pod_name", "$1", "pod", "(.+)")
+          record: kubecost_savings_running_pods
+        - expr: sum(rate(container_cpu_usage_seconds_total{container_name!="",container_name!="POD",instance!=""}[5m])) by (namespace, pod_name, container_name, instance)
+          record: kubecost_savings_container_cpu_usage_seconds
+        - expr: sum(container_memory_working_set_bytes{container_name!="",container_name!="POD",instance!=""}) by (namespace, pod_name, container_name, instance)
+          record: kubecost_savings_container_memory_usage_bytes
+        - expr: avg(sum(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace!="kube-system"}) by (pod, namespace, instance)) by (pod, namespace)
+          record: kubecost_savings_pod_requests_cpu_cores
+        - expr: avg(sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace!="kube-system"}) by (pod, namespace, instance)) by (pod, namespace)
+          record: kubecost_savings_pod_requests_memory_bytes

--- a/helx/charts/monitoring/templates/kubecost_servicemonitor.yaml
+++ b/helx/charts/monitoring/templates/kubecost_servicemonitor.yaml
@@ -1,0 +1,23 @@
+# Used to scrape metrics from kubecost. Kubecost itself will query these metrics from prometheus.
+# See https://docs.kubecost.com/custom-prom.html
+# and https://prometheus-operator.dev/docs/operator/api/#servicemonitorspec
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    {{- include "monitoring.labels" . | nindent 4 }}
+    release: "{{ .Release.Name }}"
+  name: "{{ .Release.Name }}-kubecost"
+spec:
+  endpoints:
+  - path: /metrics
+    port: tcp-model
+    interval: 1m
+    scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+    - monitoring
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: monitoring
+      app.kubernetes.io/name: cost-analyzer

--- a/helx/charts/monitoring/values.yaml
+++ b/helx/charts/monitoring/values.yaml
@@ -1,0 +1,115 @@
+# These values are the same across all clusters. Put cluster-specific config in values/<clustername>.yaml
+# https://github.com/kubecost/cost-analyzer-helm-chart
+cost-analyzer:
+  enabled: true
+  # persistentVolume:
+  #   size: 32Gi
+  #   dbSize: 32Gi
+  #   existingClaim: cost-analyzer-pvc
+  # Since there is no auth unless we pay, don't let people edit things
+  readonly: true
+  reporting:
+    productAnalytics: false
+    logCollection: false
+    errorReporting: false
+    # MUST BE FALSE! Otherwise ALL of values.yaml (including secrets) will be shipped to the kubecost people!
+    valuesReporting: false
+  prometheus:
+    kube-state-metrics:
+      disabled: true
+      enabled: false
+      rbac:
+        create: false
+  global:
+    grafana:
+      enabled: false
+      domainName: monitoring-grafana.monitoring
+    prometheus:
+      enabled: false
+      fqdn: http://monitoring-kube-prometheus-prometheus.monitoring:9090
+    notifications:
+      alertmanager:
+        enabled: false
+        fqdn: http://monitoring-kube-prometheus-alertmanager.monitoring:9093
+
+# https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack
+kube-prometheus-stack:
+  prometheus-node-exporter:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  enabled: true
+  alertmanager:
+    enabled: true
+  grafana:
+    enabled: true
+    additionalDataSources:
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://monitoring-loki.monitoring:3100
+        version: 1
+  prometheusOperator:
+    enabled: true
+  prometheus:
+    prometheusSpec:
+      # Pick up all PrometheusRules and ServiceMonitors.
+      # Technically this means multiple prom-operators may collect duplicate info,
+      # but it saves a LOT of headache due to accidentally forgetting labels.
+      ruleSelector: {}
+      ruleSelectorNilUsesHelmValues: false
+      serviceMonitorSelector: {}
+      serviceMonitorSelectorNilUsesHelmValues: false
+      resources:
+        requests:
+          cpu: 1500m
+          memory: 2000Mi
+        limits:
+          cpu: 1500m
+          memory: 2000Mi
+  # kubeEtcd:
+  #   ## If your etcd is not deployed as a pod, specify IPs it can be found on
+  #   endpoints:
+  #   - 172.25.16.x
+  #   - 172.25.16.y
+  #   - 172.25.16.z
+
+# https://github.com/grafana/helm-charts/tree/main/charts/loki
+loki:
+  enabled: true
+  replicas: 3
+  persistence:
+    enabled: true
+    accessModes:
+    - ReadWriteOnce
+    size: 10Gi
+  serviceMonitor:
+    enabled: true
+  config:
+    limits_config:
+      retention_period: 90d
+
+# https://github.com/grafana/helm-charts/tree/main/charts/promtail
+promtail:
+  enabled: true
+  rbac:
+    pspEnabled: true
+  config:
+    lokiAddress: http://monitoring-loki.monitoring:3100/loki/api/v1/push
+
+falco:
+  enabled: true
+  falcosidekick:
+    enabled: true
+    config:
+      alertmanager:
+        hostport: http://alertmanager-operated.monitoring:9093
+        minimumpriority: error
+
+# Use 'htpasswd -nBb -C 7 admin some-pass-really' to create credentials for
+# username='admin' with password of 'some-pass-really'.
+basicauth-creds:

--- a/helx/values.yaml
+++ b/helx/values.yaml
@@ -16,6 +16,10 @@ image-utils:
   # -- enable/disable deployment of image-utils (imagepullsecret-patcher and
   # imagepuller)
   enabled: false
+monitoring:
+  # -- enable/disable deployment of Kubernetes monitoring charts
+  # (kube-prometheus-stack, cost-analyzer, etc.)
+  enabled: false
 nfs-server:
   # -- enable/disable deployment of nfs-server
   enabled: true

--- a/update-chart-dependencies-and-packages.sh
+++ b/update-chart-dependencies-and-packages.sh
@@ -10,6 +10,7 @@ helm package helx/charts/ambassador
 helm package helx/charts/backup-pvc-cronjob
 helm package helx/charts/helx-monitoring
 helm package helx/charts/image-utils
+helm package helx/charts/monitoring
 helm package helx/charts/nfs-server
 helm package helx/charts/nfsrods
 helm package helx/charts/nginx
@@ -20,4 +21,3 @@ helm package helx
 
 mv *.tgz docs/charts/
 helm repo index docs/charts --url https://helxplatform.github.io/devops/charts
-

--- a/update-chart-dependencies.sh
+++ b/update-chart-dependencies.sh
@@ -10,4 +10,6 @@ cd charts/helx-monitoring
 helm dependency update
 cd ../image-utils
 helm dependency update
+cd ../monitoring
+helm dependency update
 cd ../../../


### PR DESCRIPTION
Added "monitoring" helm chart that uses kube-prometheus-stack instead of loki-stack.  helx-monitoring is still there.