### PR TITLE
Retain nfsrods PV on uninstall, and document nfsrods functionality

### DIFF
--- a/helx/Chart.lock
+++ b/helx/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 0.2.5
 - name: nfsrods
   repository: ""
-  version: 0.1.5
+  version: 0.2.0
 - name: nginx
   repository: ""
   version: 0.3.3
@@ -32,5 +32,5 @@ dependencies:
 - name: tycho-api
   repository: https://helxplatform.github.io/helm-charts/
   version: 0.2-dev
-digest: sha256:0f8e84fadee4d5b11b15170508a3325f89f109716118787fd16470b1c6db77be
-generated: "2021-10-18T11:50:39.836415-04:00"
+digest: sha256:65d38868c6738087d5b50b325292ecd19519c1615a47a060e6174947f29ab9c9
+generated: "2021-11-05T15:42:32.011721-04:00"

--- a/helx/Chart.yaml
+++ b/helx/Chart.yaml
@@ -42,7 +42,7 @@ dependencies:
     version: 0.2.5
   - name: nfsrods
     condition: nfsrods.enabled
-    version: 0.1.5
+    version: 0.2.0
   - name: nginx
     condition: nginx.enabled
     version: 0.3.3

--- a/helx/charts/nfsrods/Chart.yaml
+++ b/helx/charts/nfsrods/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.5
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helx/charts/nfsrods/README.md
+++ b/helx/charts/nfsrods/README.md
@@ -1,8 +1,12 @@
 # nfsrods
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
-
 A standalone NFSv4.1 server (via nfs4j) with a Virtual File System implementation supporting the iRODS Data Management Platform.
+
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+
+`nfsrods` works by creating a fake PersistentVolume which acts as a pointer to the `nfsrods` Service IP. When a pod mounts the `nfsrods` PersistentVolume, kubelet will send NFS commands to the service IP listed in the PersistentVolume. Since Helm ensures the `service.ip` is the same in the Service and the PersistentVolume, the NFS traffic can flow as if talking to any other external NFS server.
+
+NOTE: The PersistentVolume and Claim are set be retained if the helm chart is uninstalled. This allows for non-cluster-admins to re-deploy since they do not have the permission to create and delete PersistentVolumes.
 
 ## Values
 
@@ -36,7 +40,7 @@ A standalone NFSv4.1 server (via nfs4j) with a Virtual File System implementatio
 | server.nfs_server.port | int | `2049` |  |
 | server.nfs_server.user_access_refresh_time_in_milliseconds | int | `1000` |  |
 | server.nfs_server.user_information_refresh_time_in_milliseconds | int | `3600000` |  |
-| service.ip | string | `"10.233.58.200"` |  |
+| service.ip | string | `"10.233.58.200"` | NOTE: This IP must be a valid, unused IP in the cluster's serviceCIDR |
 | service.mountdPort | int | `20048` |  |
 | service.nfsPort | int | `2049` |  |
 | service.rpcbindPort | int | `111` |  |
@@ -44,8 +48,8 @@ A standalone NFSv4.1 server (via nfs4j) with a Virtual File System implementatio
 | sharedStorage.createPV | bool | `true` |  |
 | sharedStorage.createPVC | bool | `true` |  |
 | sharedStorage.nfs.path | string | `"/"` |  |
-| sharedStorage.storageClass | string | `"nfsrods-sc"` |  |
-| sharedStorage.storageSize | string | `"100Gi"` |  |
+| sharedStorage.storageClass | string | `"nfsrods-sc"` | This storageClass doesn't need to exist in the cluster since the PVC is directly selecting the PV |
+| sharedStorage.storageSize | string | `"100Gi"` | No data is actually stored here, just a pointer to the nfsrods service IP. |
 | tolerations | list | `[]` |  |
 
 ----------------------------------------------

--- a/helx/charts/nfsrods/README.md.gotmpl
+++ b/helx/charts/nfsrods/README.md.gotmpl
@@ -1,0 +1,12 @@
+{{ template "chart.header" . }}
+{{ template "chart.description" . }}
+
+{{ template "chart.versionBadge" .  }}{{ template "chart.typeBadge" .  }}{{ template "chart.appVersionBadge" .  }}
+
+`nfsrods` works by creating a fake PersistentVolume which acts as a pointer to the `nfsrods` Service IP. When a pod mounts the `nfsrods` PersistentVolume, kubelet will send NFS commands to the service IP listed in the PersistentVolume. Since Helm ensures the `service.ip` is the same in the Service and the PersistentVolume, the NFS traffic can flow as if talking to any other external NFS server.
+
+NOTE: The PersistentVolume and Claim are set be retained if the helm chart is uninstalled. This allows for non-cluster-admins to re-deploy since they do not have the permission to create and delete PersistentVolumes.
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/helx/charts/nfsrods/templates/nfsrods-shared-storage.yaml
+++ b/helx/charts/nfsrods/templates/nfsrods-shared-storage.yaml
@@ -3,6 +3,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ .Values.global.stdnfsPvc }}
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     {{- include "nfsrods.labels" . | nindent 4 }}
 spec:
@@ -19,6 +21,8 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: {{ include "nfsrods.fullname" . }}-pv
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   capacity:
     storage: {{ .Values.sharedStorage.storageSize }}

--- a/helx/charts/nfsrods/values.yaml
+++ b/helx/charts/nfsrods/values.yaml
@@ -31,6 +31,7 @@ service:
   nfsPort: 2049
   mountdPort: 20048
   rpcbindPort: 111
+  # -- NOTE: This IP must be a valid, unused IP in the cluster's serviceCIDR
   ip: 10.233.58.200
 
 resources:
@@ -52,7 +53,9 @@ runArgs: "/usr/sbin/useradd -m -u 1000 -s /bin/bash rods; ./start.sh"
 sharedStorage:
   createPVC: true
   createPV: true
+  # -- No data is actually stored here, just a pointer to the nfsrods service IP.
   storageSize: 100Gi
+  # -- This storageClass doesn't need to exist in the cluster since the PVC is directly selecting the PV
   storageClass: nfsrods-sc
   nfs:
     path: /


### PR DESCRIPTION
Since PersistentVolumes are not namespace-scoped, only cluster admins can install nfsrods and create the PV. However, if a developer uninstalls the helm chart, the PVC will be deleted, leaving the PV in the "Released" state, unable to be re-mounted.

This PR fixes that issue by telling helm not to delete the PV or PVC when uninstalled. After initial installation, non-cluster-admins can delete and redeploy the helm chart as many times as they like.

Also documented some of the inner workings of the nfsrods chart.