### PR TITLE
Remove unneeded privileges from nfsrods

### DIFF
--- a/helx/Chart.lock
+++ b/helx/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 0.2.5
 - name: nfsrods
   repository: ""
-  version: 2.0.0
+  version: 2.0.1
 - name: nginx
   repository: ""
   version: 0.3.4
@@ -35,5 +35,5 @@ dependencies:
 - name: tycho-api
   repository: https://helxplatform.github.io/helm-charts/
   version: 0.2-dev
-digest: sha256:03508f04365bb2289fed9150c17202222895c0eb95b9df9437c8f0ed1f4d245d
-generated: "2022-01-26T15:02:52.247881-05:00"
+digest: sha256:dccf18e14fe8fe93c5b2a942e70ac8c5d410affb7be0531907069be88f901a66
+generated: "2022-02-07T14:52:57.841379-05:00"

--- a/helx/Chart.yaml
+++ b/helx/Chart.yaml
@@ -46,7 +46,7 @@ dependencies:
     version: 0.2.5
   - name: nfsrods
     condition: nfsrods.enabled
-    version: 2.0.0
+    version: 2.0.1
   - name: nginx
     condition: nginx.enabled
     version: 0.3.4

--- a/helx/charts/nfsrods/Chart.yaml
+++ b/helx/charts/nfsrods/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.0
+version: 2.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helx/charts/nfsrods/README.md
+++ b/helx/charts/nfsrods/README.md
@@ -2,7 +2,7 @@
 
 A standalone NFSv4.1 server (via nfs4j) with a Virtual File System implementation supporting the iRODS Data Management Platform.
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.4](https://img.shields.io/badge/AppVersion-2.0.4-informational?style=flat-square)
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.4](https://img.shields.io/badge/AppVersion-2.0.4-informational?style=flat-square)
 
 `nfsrods` works by creating a fake PersistentVolume which acts as a pointer to the `nfsrods` Service IP. When a pod mounts the `nfsrods` PersistentVolume, kubelet will send NFS commands to the service IP listed in the PersistentVolume. Since Helm ensures the `service.ip` is the same in the Service and the PersistentVolume, the NFS traffic can flow as if talking to any other external NFS server.
 
@@ -27,7 +27,7 @@ NOTE: The PersistentVolume and Claim are set be retained if the helm chart is un
 | resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.memory | string | `"128Mi"` |  |
 | runArgs | string | `"/usr/sbin/useradd -m -u 1000 -s /bin/bash rods; ./start.sh"` |  |
-| securityContext.privileged | bool | `true` |  |
+| securityContext | object | `{}` |  |
 | server.irods_client.default_resource | string | `"rootResc"` |  |
 | server.irods_client.host | string | `"example.com"` |  |
 | server.irods_client.port | int | `1247` |  |

--- a/helx/charts/nfsrods/values.yaml
+++ b/helx/charts/nfsrods/values.yaml
@@ -17,14 +17,13 @@ fullnameOverride: ""
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext:
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
-  privileged: true
 
 service:
   type: ClusterIP


### PR DESCRIPTION
NFSrods performs the NFS operations entirely in userspace, so as a result it does not need privileged access to the underlying OS. PJ, Warren, and I have tested this change in Sterling (where privileged pods are not allowed since they break multi-tenancy) and nfsrods appears to run happily.