### PR TITLE
Checkin jenkins agent

### DIFF
--- a/cicd/jenkins/jenkins-agent/Dockerfile
+++ b/cicd/jenkins/jenkins-agent/Dockerfile
@@ -10,10 +10,7 @@ USER root
 # Note: removed libreadline-gplv2-dev and python-pip
 RUN echo "deb http://ftp.debian.org/debian stable main contrib non-free" > /etc/apt/sources.list && \
   apt-get update -qq && \
-  apt-get install -qqy curl && \
-  curl -L http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.1_1.1.1k-1_amd64.deb -o ./libssl1.1_1.1.1k-1_amd64.deb && \
-  apt-get install --allow-downgrades -y ./libssl1.1_1.1.1k-1_amd64.deb && \
-  apt-get install -qqy acl apt-transport-https build-essential ca-certificates gettext-base \
+  apt-get install -qqy curl libssl1.1 acl apt-transport-https build-essential ca-certificates gettext-base \
     gnupg gnupg2 less libc6-dev libffi-dev libgdm-dev libncursesw5-dev libsqlite3-dev \
     libbz2-dev lsb-release make npm python-apt-common python3 python3-venv python3-dbus python3-gi \
     python python3-software-properties python3-wheel python3-setuptools ruby ruby-bundler \
@@ -50,25 +47,7 @@ RUN add-apt-repository \
   chmod +x /usr/local/bin/clair-scanner && \
   ln -s /usr/local/bin/clair-scanner /usr/bin/clair-scanner
 
-RUN curl -L https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz -o ./Python-3.9.6.tgz && \
-  tar xzf Python-3.9.6.tgz && \
-  cd Python-3.9.6 && \
-  ./configure --enable-optimizations && \
-  make altinstall && \
-  python3.9 -V && \
-  pip3.9 -V && \
-  rm /usr/bin/python3 && \
-  ln -s /usr/local/bin/python3.9 /usr/bin/python3 && \
-  rm -f /usr/bin/pip3 && \
-  ln -s /usr/local/bin/pip3.9 /usr/bin/pip3 && \
-  rm -f /usr/bin/pydoc3 && \
-  ln -s /usr/local/bin/pydoc3.9 /usr/bin/pydoc3 && \
-  rm -f /usr/bin/python3-config && \
-  ln -s /usr/local/bin/python3.9-config /usr/bin/python3-config && \
-  awk '!x{x=sub("/bin/python3","/local/bin/python3.9.6")}1' /usr/bin/lsb_release > /tmp/lsb_release.tmp && \
-  mv /tmp/lsb_release.tmp /usr/bin/lsb_release && \
-  python3 -V && \
-  pip3 -V
+RUN apt-get install python3.9
 
 # INSTALL NODE.JS:
 RUN npm cache clean --force && \

--- a/cicd/jenkins/jenkins-agent/Dockerfile
+++ b/cicd/jenkins/jenkins-agent/Dockerfile
@@ -1,0 +1,101 @@
+FROM jenkins/inbound-agent:4.13-2-jdk11
+
+ARG JENKINSUID=1000
+ARG JENKINSGID=1000
+ARG DOCKERGID=999
+ARG SUDOGID=27
+
+USER root
+
+# Note: removed libreadline-gplv2-dev and python-pip
+RUN echo "deb http://ftp.debian.org/debian stable main contrib non-free" > /etc/apt/sources.list && \
+  apt-get update -qq && \
+  apt-get install -qqy curl && \
+  curl -L http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.1_1.1.1k-1_amd64.deb -o ./libssl1.1_1.1.1k-1_amd64.deb && \
+  apt-get install --allow-downgrades -y ./libssl1.1_1.1.1k-1_amd64.deb && \
+  apt-get install -qqy acl apt-transport-https build-essential ca-certificates gettext-base \
+    gnupg gnupg2 less libc6-dev libffi-dev libgdm-dev libncursesw5-dev libsqlite3-dev \
+    libbz2-dev lsb-release make npm python-apt-common python3 python3-venv python3-dbus python3-gi \
+    python python3-software-properties python3-wheel python3-setuptools ruby ruby-bundler \
+    software-properties-common sudo tk-dev vim-tiny zlib1g-dev libssl-dev
+
+RUN apt-get install -qqy fonts-liberation libasound2 libatk1.0-0 libc6 libcairo2 \
+    libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm-dev libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 \
+    libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 \
+    libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 \
+    libxrender1 libxss1 libxtst6 wget xdg-utils && \
+  curl -L http://ftp.us.debian.org/debian/pool/main/libi/libindicator/libindicator7_0.5.0-4_amd64.deb \
+     -o libindicator7_0.5.0-4_amd64.deb && \
+  apt-get -y install ./libindicator7_0.5.0-4_amd64.deb && \
+  curl -L http://ftp.us.debian.org/debian/pool/main/liba/libappindicator/libappindicator1_0.4.92-7_amd64.deb \
+     -o ./libappindicator1_0.4.92-7_amd64.deb && \
+  apt-get -y install ./libappindicator1_0.4.92-7_amd64.deb
+
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | \
+  apt-key add - && \
+  apt-key fingerprint 0EBFCD88
+
+RUN add-apt-repository \
+  "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
+  apt-get update && \
+  apt-get install -qqy docker-ce docker-ce-cli && \
+  curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64" \
+     -o /usr/local/bin/docker-compose && \
+  chmod +x /usr/local/bin/docker-compose && \
+  ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
+  curl -L https://github.com/arminc/clair-scanner/releases/download/v12/clair-scanner_linux_amd64 \
+     -o /usr/local/bin/clair-scanner && \
+  chmod +x /usr/local/bin/clair-scanner && \
+  ln -s /usr/local/bin/clair-scanner /usr/bin/clair-scanner
+
+RUN curl -L https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz -o ./Python-3.9.6.tgz && \
+  tar xzf Python-3.9.6.tgz && \
+  cd Python-3.9.6 && \
+  ./configure --enable-optimizations && \
+  make altinstall && \
+  python3.9 -V && \
+  pip3.9 -V && \
+  rm /usr/bin/python3 && \
+  ln -s /usr/local/bin/python3.9 /usr/bin/python3 && \
+  rm -f /usr/bin/pip3 && \
+  ln -s /usr/local/bin/pip3.9 /usr/bin/pip3 && \
+  rm -f /usr/bin/pydoc3 && \
+  ln -s /usr/local/bin/pydoc3.9 /usr/bin/pydoc3 && \
+  rm -f /usr/bin/python3-config && \
+  ln -s /usr/local/bin/python3.9-config /usr/bin/python3-config && \
+  awk '!x{x=sub("/bin/python3","/local/bin/python3.9.6")}1' /usr/bin/lsb_release > /tmp/lsb_release.tmp && \
+  mv /tmp/lsb_release.tmp /usr/bin/lsb_release && \
+  python3 -V && \
+  pip3 -V
+
+# INSTALL NODE.JS:
+RUN npm cache clean --force && \
+  npm install npm -g && \
+  npm install n -g && \
+  n lts
+
+ENV USER jenkins
+ENV UID 1000
+
+# Setup users and groups
+RUN groupmod -g ${JENKINSGID} jenkins && \
+  groupmod -g ${DOCKERGID} docker && \
+  usermod -g ${JENKINSGID} -G ${DOCKERGID},${SUDOGID} -u ${JENKINSUID} jenkins && \
+  usermod -p '$6$zltyyttlas$DwfqAq2l5HlUE2WnEUhFtAi1Je3YE2uH50fdyyUmUjoXzmzZGm3ch4eaT/N6O62JgSKdhy0tslF/f8dNdXZQt/' jenkins && \
+  touch /var/run/docker.sock && \
+  chown root:docker /var/run/docker.sock && \
+  chmod 660 /var/run/docker.sock && \
+  ls -l /var/run/docker.sock && \
+  setfacl -m user:$USER:rw /var/run/docker.sock && \
+  getfacl /var/run/docker.sock
+
+USER jenkins
+
+# Create empty whitelist so command can be set up once for all time
+RUN pwd && \
+  ls -l && \
+  mkdir /home/jenkins/clair && \
+  mkdir /home/jenkins/clair/whitelists && \
+  touch /home/jenkins/clair/whitelists/common-whitelist.yaml

--- a/cicd/jenkins/jenkins-agent/Makefile
+++ b/cicd/jenkins/jenkins-agent/Makefile
@@ -1,8 +1,9 @@
 TAG_VERSION := v0.0.16
+REPO := containers.renci.org/helxplatform/agent-docker
 
 .PHONY: push
 push:
-	docker build . -t helxplatform/agent-docker:${TAG_VERSION}
-	docker tag helxplatform/agent-docker:${TAG_VERSION} helxplatform/agent-docker:latest
-	docker push helxplatform/agent-docker:${TAG_VERSION}
-	docker push helxplatform/agent-docker:latest
+	docker build . -t ${REPO}:${TAG_VERSION}
+	docker tag ${REPO}:${TAG_VERSION} ${REPO}:latest
+	docker push ${REPO}:${TAG_VERSION}
+	docker push ${REPO}:latest

--- a/cicd/jenkins/jenkins-agent/Makefile
+++ b/cicd/jenkins/jenkins-agent/Makefile
@@ -1,0 +1,8 @@
+TAG_VERSION := v0.0.16
+
+.PHONY: push
+push:
+	docker build . -t helxplatform/agent-docker:${TAG_VERSION}
+	docker tag helxplatform/agent-docker:${TAG_VERSION} helxplatform/agent-docker:latest
+	docker push helxplatform/agent-docker:${TAG_VERSION}
+	docker push helxplatform/agent-docker:latest

--- a/cicd/jenkins/jenkins-agent/README.md
+++ b/cicd/jenkins/jenkins-agent/README.md
@@ -10,29 +10,19 @@ The VM jenkins-docker-builder.edc.renci.org was created in response to RT#5278. 
 * Enable and start docker. Add users to docker group: `usermod -aG docker <user>`
   - Allowed users: machaffe, tcheek, jeffw, bennettc
 * Allow the Jenkins gid (1000) to access the docker socket: `sudo setfacl -m g:1000:rw /var/run/docker.sock`
+* Copy this readme and docker-compose.yml into `/opt/jenkins`
+* Make /opt/jenkins group-accessible via the "renci" group
 * Create a new agent in the Jenkins UI, copy the secret key
-* Run the jenkins agent (using websockets):
+* Insert the secret key into docker-compose.yml, in place of `${AGENT_SECRET}`
+* Start the agent and docuum:
 
 ```
-docker run -d --name agent -v /var/run/docker.sock:/var/run/docker.sock containers.renci.org/helxplatform/agent-docker:v0.0.16 -url https://jenkins.apps.renci.org/ -webSocket -workDir /home/jenkins/agent $AGENT_SECRET jenkins-docker-builder.edc.renci.org
+cd /opt/jenkins
+docker compose up -d
 ```
 
 The image is pushed here (manually for now): https://containers.renci.org/harbor/projects/5/repositories/agent-docker/info-tab
 
 ## Cleaning up old images
 
-Docker images accumulate over time, so we use https://github.com/stepchowfun/docuum to clean them up when they use >50GB:
-
-```
-docker run \
-  --init -d --restart=always \
-  --name docuum \
-  --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume docuum:/root \
-  stephanmisc/docuum --threshold '50 GB'
-
-```
-
-## TODO
-
-* Use systemd to start docuum and the agent automatically on startup
+Docker images accumulate over time, so we use https://github.com/stepchowfun/docuum to clean them up when they use >60GB of the 100GB disk.

--- a/cicd/jenkins/jenkins-agent/README.md
+++ b/cicd/jenkins/jenkins-agent/README.md
@@ -1,0 +1,18 @@
+# jenkins-docker-builder.edc.renci.org
+
+The VM jenkins-docker-builder.edc.renci.org was created in response to RT#5278. It runs a Jenkins agent that connects to jenkins.apps.renci.org (in Sterling) and runs jobs that cannot run inside Sterling, such as docker-compose jobs or jobs that require a lot of ephemeral-storage space.
+
+## How this VM was set up
+
+* Install docker: https://docs.docker.com/engine/install/centos/
+* Enable and start docker. Add users to docker group: `usermod -aG docker <user>`
+  - Allowed users: machaffe, tcheek, jeffw, bennettc
+* Allow the Jenkins gid (1000) to access the docker socket: `sudo setfacl -m g:1000:rw /var/run/docker.sock`
+* Create a new agent in the Jenkins UI, copy the secret ket
+* Run the jenkins agent (using websockets):
+
+```
+docker run -d --name agent -v /var/run/docker.sock:/var/run/docker.sock containers.renci.org/helxplatform/agent-docker:v0.0.16 -url https://jenkins.apps.renci.org/ -webSocket -workDir /home/jenkins/agent $AGENT_SECRET jenkins-docker-builder.edc.renci.org
+```
+
+The image is pushed here (manually for now): https://containers.renci.org/harbor/projects/5/repositories/agent-docker/info-tab

--- a/cicd/jenkins/jenkins-agent/README.md
+++ b/cicd/jenkins/jenkins-agent/README.md
@@ -4,6 +4,7 @@ The VM jenkins-docker-builder.edc.renci.org was created in response to RT#5278. 
 
 ## How this VM was set up
 
+* Set up the NAT Gateway for outbound internet access: https://aciswiki.edc.renci.org/index.php?title=EDC_NAT_Gateway
 * Install docker: https://docs.docker.com/engine/install/centos/
 * Enable and start docker. Add users to docker group: `usermod -aG docker <user>`
   - Allowed users: machaffe, tcheek, jeffw, bennettc

--- a/cicd/jenkins/jenkins-agent/README.md
+++ b/cicd/jenkins/jenkins-agent/README.md
@@ -9,7 +9,7 @@ The VM jenkins-docker-builder.edc.renci.org was created in response to RT#5278. 
 * Enable and start docker. Add users to docker group: `usermod -aG docker <user>`
   - Allowed users: machaffe, tcheek, jeffw, bennettc
 * Allow the Jenkins gid (1000) to access the docker socket: `sudo setfacl -m g:1000:rw /var/run/docker.sock`
-* Create a new agent in the Jenkins UI, copy the secret ket
+* Create a new agent in the Jenkins UI, copy the secret key
 * Run the jenkins agent (using websockets):
 
 ```

--- a/cicd/jenkins/jenkins-agent/README.md
+++ b/cicd/jenkins/jenkins-agent/README.md
@@ -6,6 +6,7 @@ The VM jenkins-docker-builder.edc.renci.org was created in response to RT#5278. 
 
 * Set up the NAT Gateway for outbound internet access: https://aciswiki.edc.renci.org/index.php?title=EDC_NAT_Gateway
 * Install docker: https://docs.docker.com/engine/install/centos/
+* Configure docker to rotate container logs: https://docs.docker.com/config/containers/logging/configure/
 * Enable and start docker. Add users to docker group: `usermod -aG docker <user>`
   - Allowed users: machaffe, tcheek, jeffw, bennettc
 * Allow the Jenkins gid (1000) to access the docker socket: `sudo setfacl -m g:1000:rw /var/run/docker.sock`
@@ -17,3 +18,21 @@ docker run -d --name agent -v /var/run/docker.sock:/var/run/docker.sock containe
 ```
 
 The image is pushed here (manually for now): https://containers.renci.org/harbor/projects/5/repositories/agent-docker/info-tab
+
+## Cleaning up old images
+
+Docker images accumulate over time, so we use https://github.com/stepchowfun/docuum to clean them up when they use >50GB:
+
+```
+docker run \
+  --init -d --restart=always \
+  --name docuum \
+  --volume /var/run/docker.sock:/var/run/docker.sock \
+  --volume docuum:/root \
+  stephanmisc/docuum --threshold '50 GB'
+
+```
+
+## TODO
+
+* Use systemd to start docuum and the agent automatically on startup

--- a/cicd/jenkins/jenkins-agent/docker-compose.yml
+++ b/cicd/jenkins/jenkins-agent/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  agent:
+    image: containers.renci.org/helxplatform/agent-docker:v0.0.16
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: -url https://jenkins.apps.renci.org/ -webSocket -workDir /home/jenkins/agent ${AGENT_SECRET} jenkins-docker-builder.edc.renci.org
+
+  docuum:
+    image: stephanmisc/docuum:0.21.1
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - docuum:/root
+    command: --threshold '60 GB'
+
+volumes:
+  # Stores data on how often images are used
+  docuum:


### PR DESCRIPTION
This PR adds @cnbennett3 's dockerfile for building our Jenkins agent, https://hub.docker.com/r/helxplatform/agent-docker

I've changed 3 things:

* Used the latest 4.13 base image
* Removed the line that installs a custom version of libssl (`1.1 k`) since that custom version is no longer served. Instead installed the normal version from debian, which is `1.1 o` I believe.
* Removed the step which compiles python 3.9 from source. The version of Debian we're using now includes python3.9 as a regular package.

Also included a Makefile which pushes to containers.renci.org (https://containers.renci.org/harbor/projects/5/repositories/agent-docker/artifacts-tab)