### PR TITLE
Add the jenkins agent user to the host's docker group

### DIFF
--- a/cicd/jenkins/jenkins-agent/Makefile
+++ b/cicd/jenkins/jenkins-agent/Makefile
@@ -1,4 +1,4 @@
-TAG_VERSION := v0.0.16
+TAG_VERSION := 1.0.3
 REPO := containers.renci.org/helxplatform/agent-docker
 
 .PHONY: push

--- a/cicd/jenkins/jenkins-agent/docker-compose.yml
+++ b/cicd/jenkins/jenkins-agent/docker-compose.yml
@@ -1,7 +1,10 @@
 services:
   agent:
-    image: containers.renci.org/helxplatform/agent-docker:v0.0.16
+    image: containers.renci.org/helxplatform/agent-docker:1.0.3
     restart: always
+    group_add:
+      # This is the GID of the docker group on the VM. The GID may be different on other VMs.
+      - "749"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     command: -url https://jenkins.apps.renci.org/ -webSocket -workDir /home/jenkins/agent ${AGENT_SECRET} jenkins-docker-builder.edc.renci.org


### PR DESCRIPTION
Chuck noticed permission denied errors when the jenkins agent tried to use the docker socket. This is because the "docker" group inside and outside the container have different GIDs.

I know that I can change the GID of the docker group inside the container by rebuilding the image, but I figure this change is less disruptive.

Also bumped the version to the one @waTeim built.